### PR TITLE
Update Gradle deps for Sponge 7.4.0

### DIFF
--- a/ap/build.gradle
+++ b/ap/build.gradle
@@ -2,7 +2,7 @@
 version = '1.0.0-SNAPSHOT'
 
 dependencies {
-    compile 'com.google.guava:guava:17.0'
-    compile 'org.apache.commons:commons-lang3:3.3.2'
+    implementation 'com.google.guava:guava:17.0'
+    implementation 'org.apache.commons:commons-lang3:3.3.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,26 @@
 // Apply Gradle plugins
-plugins {
-    id 'org.spongepowered.plugin' version '0.5.1'
-    id 'checkstyle'
-
-    id 'net.minecrell.licenser' version '0.1.3'
-    id 'net.minecrell.gitpatcher' version '0.8'
-    id 'blue.lapis.methodremapper' version '0.2'
-
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url 'https://repo.spongepowered.org/maven' }
+        maven { url 'https://plugins.gradle.org/m2' }
+    }
+    dependencies {
+        classpath 'org.spongepowered:plugin-meta:0.1.1'
+        classpath 'org.spongepowered:SpongeGradle:0.5.1'
+        classpath 'gradle.plugin.net.minecrell:licenser:0.1.3'
+        classpath 'gradle.plugin.net.minecrell:gitpatcher:0.8'
+        classpath 'gradle.plugin.blue.lapis:methodremapper:0.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+    }
 }
+
+apply plugin: 'org.spongepowered.plugin'
+apply plugin: 'checkstyle'
+apply plugin: 'net.minecrell.licenser'
+apply plugin: 'net.minecrell.gitpatcher'
+apply plugin: 'blue.lapis.methodremapper'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 defaultTasks 'clean', 'licenseFormat', 'build'
 
@@ -69,20 +81,19 @@ configurations {
 
 // Project dependencies
 dependencies {
-    compile project(':ap')
+    implementation project(':ap')
 
-    // To update, go to https://repo.spongepowered.org/maven/org/spongepowered/spongeapi/2.1-SNAPSHOT/
-    // Then pick latest version (or whatever version you want)
-    compile 'org.spongepowered:spongeapi:4.0.3'
-    runtime 'blue.lapis.methodremapper:tweaker:0.1'
+    // Updated to SpongeAPI 7.4.0
+    implementation 'org.spongepowered:spongeapi:7.4.0'
+    runtimeOnly 'blue.lapis.methodremapper:tweaker:0.1'
 
     shadow project('Porekit')
-    shadowRuntime 'mysql:mysql-connector-java:5.1.38'
+    shadowRuntimeOnly 'mysql:mysql-connector-java:5.1.38'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testRuntime 'org.slf4j:slf4j-simple:1.7.13'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.13'
 }
 
 allprojects {

--- a/bukkit.gradle
+++ b/bukkit.gradle
@@ -1,20 +1,19 @@
 defaultTasks 'clean', 'build'
 
-version = '1.8.8-R0.1-SNAPSHOT' // TODO: Keep up to date
+version = '1.12.2-R0.1-SNAPSHOT'
 
 // Project dependencies
 dependencies {
-    // TODO: Keep up to date
-    compile 'commons-lang:commons-lang:2.6'
+    implementation 'commons-lang:commons-lang:2.6'
     // Not sure why this is including junit as dependency
-    compile('com.googlecode.json-simple:json-simple:1.1.1') {
+    implementation('com.googlecode.json-simple:json-simple:1.1.1') {
         exclude module: 'junit'
     }
-    compile 'com.google.guava:guava:17.0'
-    compile 'com.google.code.gson:gson:2.2.4'
-    compile 'org.avaje:ebean:2.8.1'
-    compile 'org.yaml:snakeyaml:1.16'
+    implementation 'com.google.guava:guava:17.0'
+    implementation 'com.google.code.gson:gson:2.2.4'
+    implementation 'org.avaje:ebean:2.8.1'
+    implementation 'org.yaml:snakeyaml:1.16'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
 }


### PR DESCRIPTION
## Summary
- use buildscript and plugins for Gradle 2.x
- update dependencies to SpongeAPI 7.4.0
- bump Spigot base to 1.12.2
- modernise dependency declarations

## Testing
- `./gradlew assemble` *(fails: Could not resolve SpongeGradle:0.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_6882a8080240832ea9721cbb5a4df0e9