### PR TITLE
Implement whitelist and world info in PoreServer

### DIFF
--- a/src/main/java/blue/lapis/pore/impl/PoreServer.java
+++ b/src/main/java/blue/lapis/pore/impl/PoreServer.java
@@ -30,6 +30,8 @@ import blue.lapis.pore.converter.wrapper.WrapperConverter;
 import blue.lapis.pore.impl.command.PoreCommandMap;
 import blue.lapis.pore.impl.command.PoreConsoleCommandSender;
 import blue.lapis.pore.impl.entity.PorePlayer;
+import blue.lapis.pore.impl.PoreOfflinePlayer;
+import blue.lapis.pore.converter.type.world.GeneratorTypeConverter;
 import blue.lapis.pore.impl.help.PoreHelpMap;
 import blue.lapis.pore.impl.scheduler.PoreBukkitScheduler;
 import blue.lapis.pore.impl.util.PoreCachedServerIcon;
@@ -40,6 +42,7 @@ import blue.lapis.pore.util.PoreWrapper;
 import com.avaje.ebean.config.ServerConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.NotImplementedException;
 import org.bukkit.BanList;
@@ -86,9 +89,12 @@ import org.bukkit.util.permissions.DefaultPermissions;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.service.whitelist.WhitelistService;
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.util.GuavaCollectors;
 import org.spongepowered.api.util.ban.Ban;
+import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -268,32 +274,38 @@ public class PoreServer extends PoreWrapper<org.spongepowered.api.Server> implem
 
     @Override
     public String getServerName() {
-        throw new NotImplementedException("TODO");
+        return game.getPlatform().getImplementation().getName();
     }
 
     @Override
     public String getServerId() {
-        throw new NotImplementedException("TODO");
+        return game.getPlatform().getImplementation().getId();
     }
 
     @Override
     public String getWorldType() {
-        throw new NotImplementedException("TODO");
+        return getHandle().getDefaultWorld()
+                .map(p -> GeneratorTypeConverter.of(p.getGeneratorType()).getName())
+                .orElse("DEFAULT");
     }
 
     @Override
     public boolean getGenerateStructures() {
-        throw new NotImplementedException("TODO");
+        return getHandle().getDefaultWorld()
+                .map(WorldProperties::usesMapFeatures)
+                .orElse(false);
     }
 
     @Override
     public boolean getAllowEnd() {
-        throw new NotImplementedException("TODO");
+        return getHandle().getAllWorldProperties().stream()
+                .anyMatch(p -> p.getDimensionType() == DimensionTypes.THE_END);
     }
 
     @Override
     public boolean getAllowNether() {
-        throw new NotImplementedException("TODO");
+        return getHandle().getAllWorldProperties().stream()
+                .anyMatch(p -> p.getDimensionType() == DimensionTypes.NETHER);
     }
 
     @Override
@@ -308,12 +320,22 @@ public class PoreServer extends PoreWrapper<org.spongepowered.api.Server> implem
 
     @Override
     public Set<OfflinePlayer> getWhitelistedPlayers() {
-        throw new NotImplementedException("TODO");
+        Optional<WhitelistService> ws = game.getServiceManager().provide(WhitelistService.class);
+        if (!ws.isPresent()) {
+            return ImmutableSet.of();
+        }
+        UserStorageService uss = game.getServiceManager().provideUnchecked(UserStorageService.class);
+        return ws.get().getWhitelistedProfiles().stream()
+                .map(uss::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(PoreOfflinePlayer::of)
+                .collect(GuavaCollectors.toImmutableSet());
     }
 
     @Override
     public void reloadWhitelist() {
-        throw new NotImplementedException("TODO");
+        // Sponge automatically persists whitelist changes, nothing to reload
     }
 
     @Override

--- a/src/test/java/blue/lapis/pore/impl/PoreServerTest.java
+++ b/src/test/java/blue/lapis/pore/impl/PoreServerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Pore
+ * Copyright (c) 2014-2016, Lapis <https://github.com/LapisBlue>
+ *
+ * The MIT License
+ */
+package blue.lapis.pore.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import blue.lapis.pore.PoreTests;
+import blue.lapis.pore.converter.type.world.GeneratorTypeConverter;
+
+import com.google.common.collect.ImmutableList;
+import org.bukkit.OfflinePlayer;
+import org.junit.Before;
+import org.junit.Test;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Platform;
+import org.spongepowered.api.Server;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.api.service.ServiceManager;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.service.whitelist.WhitelistService;
+import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.api.world.GeneratorTypes;
+import org.spongepowered.api.world.storage.WorldProperties;
+import org.spongepowered.api.entity.living.player.User;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public class PoreServerTest {
+
+    private PoreServer server;
+    private Game game;
+    private Server spongeServer;
+    private ServiceManager services;
+    private WhitelistService whitelist;
+    private UserStorageService users;
+    private WorldProperties defaultProps;
+
+    @Before
+    public void setUp() {
+        PoreTests.mockPlugin();
+
+        game = mock(Game.class);
+        spongeServer = mock(Server.class);
+        when(game.getServer()).thenReturn(spongeServer);
+
+        Platform platform = mock(Platform.class);
+        PluginContainer impl = mock(PluginContainer.class);
+        when(impl.getName()).thenReturn("ImplName");
+        when(impl.getId()).thenReturn("impl-id");
+        when(platform.getImplementation()).thenReturn(impl);
+        when(game.getPlatform()).thenReturn(platform);
+
+        defaultProps = mock(WorldProperties.class);
+        when(spongeServer.getDefaultWorld()).thenReturn(Optional.of(defaultProps));
+
+        WorldProperties endProps = mock(WorldProperties.class);
+        when(endProps.getDimensionType()).thenReturn(DimensionTypes.THE_END);
+        WorldProperties netherProps = mock(WorldProperties.class);
+        when(netherProps.getDimensionType()).thenReturn(DimensionTypes.NETHER);
+        when(spongeServer.getAllWorldProperties()).thenReturn(ImmutableList.of(defaultProps, endProps, netherProps));
+
+        services = mock(ServiceManager.class);
+        whitelist = mock(WhitelistService.class);
+        users = mock(UserStorageService.class);
+        when(game.getServiceManager()).thenReturn(services);
+        when(services.provide(WhitelistService.class)).thenReturn(Optional.of(whitelist));
+        when(services.provideUnchecked(UserStorageService.class)).thenReturn(users);
+
+        server = new PoreServer(game, org.slf4j.LoggerFactory.getLogger("test"));
+    }
+
+    @Test
+    public void testNameAndId() {
+        assertEquals("ImplName", server.getServerName());
+        assertEquals("impl-id", server.getServerId());
+    }
+
+    @Test
+    public void testWorldProperties() {
+        when(defaultProps.getGeneratorType()).thenReturn(GeneratorTypes.FLAT);
+        when(defaultProps.usesMapFeatures()).thenReturn(true);
+
+        assertEquals(GeneratorTypeConverter.of(GeneratorTypes.FLAT).getName(), server.getWorldType());
+        assertTrue(server.getGenerateStructures());
+        assertTrue(server.getAllowEnd());
+        assertTrue(server.getAllowNether());
+    }
+
+    @Test
+    public void testWhitelist() {
+        GameProfile profile = GameProfile.of(UUID.randomUUID(), "tester");
+        User user = mock(User.class);
+        when(users.get(profile)).thenReturn(Optional.of(user));
+        when(whitelist.getWhitelistedProfiles()).thenReturn(ImmutableList.of(profile));
+
+        when(spongeServer.hasWhitelist()).thenReturn(false);
+        assertTrue(!server.hasWhitelist());
+        server.setWhitelist(true);
+        verify(spongeServer).setHasWhitelist(true);
+
+        Set<OfflinePlayer> players = server.getWhitelistedPlayers();
+        assertEquals(1, players.size());
+    }
+}


### PR DESCRIPTION
## Summary
- implement server id/name, generator type and whitelist behaviour
- use Sponge APIs for server and world configuration
- add unit tests covering whitelist, world and server name lookup

## Testing
- `./gradlew test` *(fails: Could not determine java version from '21.0.2')*

------
https://chatgpt.com/codex/tasks/task_e_6882a80bd368832e856da0cd2ee9114c