### PR TITLE
Implement basic scoreboard stubs

### DIFF
--- a/src/main/java/blue/lapis/pore/impl/PoreServer.java
+++ b/src/main/java/blue/lapis/pore/impl/PoreServer.java
@@ -80,6 +80,8 @@ import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.plugin.messaging.StandardMessenger;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scoreboard.ScoreboardManager;
+import blue.lapis.pore.impl.scoreboard.PoreScoreboardManager;
+import org.spongepowered.api.scoreboard.Scoreboard;
 import org.bukkit.util.CachedServerIcon;
 import org.bukkit.util.StringUtil;
 import org.bukkit.util.permissions.DefaultPermissions;
@@ -754,7 +756,7 @@ public class PoreServer extends PoreWrapper<org.spongepowered.api.Server> implem
 
     @Override
     public ScoreboardManager getScoreboardManager() {
-        throw new NotImplementedException("TODO");
+        return new PoreScoreboardManager(Scoreboard.builder());
     }
 
     @Override

--- a/src/main/java/blue/lapis/pore/impl/scoreboard/PoreScoreboard.java
+++ b/src/main/java/blue/lapis/pore/impl/scoreboard/PoreScoreboard.java
@@ -187,7 +187,10 @@ public class PoreScoreboard extends PoreWrapper<Scoreboard> implements org.bukki
 
     @Override
     public Set<String> getEntries() {
-        throw new NotImplementedException("TODO");
+        return Sets.newHashSet(Collections2.transform(
+                getHandle().getEntries(),
+                PoreText::convert
+        ));
     }
 
     @Override

--- a/src/main/java/blue/lapis/pore/impl/scoreboard/PoreScoreboardManager.java
+++ b/src/main/java/blue/lapis/pore/impl/scoreboard/PoreScoreboardManager.java
@@ -45,8 +45,7 @@ public class PoreScoreboardManager extends PoreWrapper<Scoreboard.Builder>
 
     @Override
     public org.bukkit.scoreboard.Scoreboard getMainScoreboard() {
-        //TODO: scoreboard are per-world
-        throw new NotImplementedException("TODO");
+        return PoreScoreboard.of(Scoreboard.builder().build());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- finish `getEntries()` to return scoreboard entry names
- return a scoreboard from `getMainScoreboard()`
- expose a scoreboard manager from `PoreServer`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882a810dccc832ea667edf9087df438